### PR TITLE
WIP: code refactor: business API endpoints

### DIFF
--- a/app/v1/businesses/views.py
+++ b/app/v1/businesses/views.py
@@ -1,0 +1,129 @@
+import os
+import random
+from flask import Flask, abort, jsonify, make_response, request
+from flask_jwt_extended import (JWTManager, create_access_token,
+                                get_jwt_identity, get_raw_jwt,
+                                jwt_required)
+
+from app import app
+from app.v1.models import WeConnect
+
+app.config['JWT_SECRET_KEY'] = os.urandom(23)
+jwt = JWTManager(app)
+weconnect = WeConnect()
+
+@app.route('/api/v1/businesses', methods=['GET'])
+@jwt_required
+def get_businesses():
+    """Returns all businesses"""
+    businesses = weconnect.get_businesses()
+    return jsonify({'businesses': businesses})
+
+
+@app.route('/api/v1/businesses/<businessId>', methods=['GET'])
+@jwt_required
+def get_business(businessId):
+    """Returns a specific business"""
+    business = weconnect.get_business(int(businessId))
+    if business is None:
+        abort(404)
+    return jsonify({'business': business})
+
+
+@app.route('/api/v1/businesses', methods=['POST'])
+@jwt_required
+def register_business():
+    """Registers a business"""
+    data = request.get_json()
+    name = data['name']
+    location = data['location']
+    description = data['description']
+    category = data['category']
+    current_user = get_jwt_identity()
+    user_id = current_user
+    if not data or not name:
+        abort(400)
+    if name is not None or description is not None or location is not None or category is not None:
+        new_business = weconnect.create_business(
+            user_id, random.randint(
+                1, 500), name, location, category, description)
+        return jsonify({'business': new_business}), 201
+    return jsonify({"response": "Empty value entered"}), 400
+
+
+@app.route('/api/v1/businesses/<businessId>', methods=['PUT'])
+@jwt_required
+def update_business(businessId):
+    """Updates a business"""
+    if int(businessId) == 0:
+        abort(404)
+    data = request.get_json()
+    name = data['name']
+    location = data['location']
+    description = data['description']
+    category = data['category']
+    current_user = get_jwt_identity()
+    user_id = current_user
+    if not data:
+        abort(400)
+    if name and isinstance(name, str) == False:
+        abort(400)
+    if description and isinstance(name, str) == False:
+        abort(400)
+    if location and isinstance(location, str) == False:
+        abort(400)
+    if category and isinstance(category, str) == False:
+        abort(400)
+
+    if name is not None or description is not None or location is not None or category is not None:
+        business = weconnect.update_business(
+            user_id, int(businessId), name, location, description, category)
+        return jsonify(business), 201
+
+
+@app.route('/api/v1/businesses/<businessId>', methods=['DELETE'])
+@jwt_required
+def delete_business(businessId):
+    """Deletes a business"""
+    if int(businessId) == 0:
+        abort(404)
+
+    current_user = get_jwt_identity()
+    user_id = current_user
+    delete_business = weconnect.delete_business(user_id, int(businessId))
+    if delete_business:
+        return jsonify({'message': 'Business deleted'})
+
+
+@app.route('/api/v1/businesses/<businessId>/reviews', methods=['POST'])
+@jwt_required
+def set_review(businessId):
+    """Adds a review to a business"""
+    data = request.get_json()
+    review = data['review']
+
+    if not data or review:
+        abort(400)
+    business_id = int(businessId)
+    new_review = weconnect.add_review(business_id, random.randint(1, 500),
+                                      review)
+    if new_review is None:
+        abort(404)
+    return jsonify(new_review), 201
+
+
+@app.route('/api/v1/businesses/<businessId>/reviews', methods=['GET'])
+@jwt_required
+def get_reviews(businessId):
+    """Returns reviews for the specified business"""
+    reviews = weconnect.get_reviews(int(businessId))
+    return jsonify({'business': reviews})
+
+@app.errorhandler(404)
+def not_found(error):
+    """This is the error handler"""
+    return make_response(jsonify({'error': 'Not found'}), 404)
+
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/tests/tests_v1/test_business.py
+++ b/tests/tests_v1/test_business.py
@@ -1,0 +1,231 @@
+import flask
+import json
+import flask_jwt_extended
+import unittest
+
+from app import app
+from app.v1 import models, users
+
+class WeConnectViews(unittest.TestCase):
+    """Tests the enpoints contains in views.py"""
+
+    def setUp(self):
+        self.weconnect_test = app.test_client(self)
+        models.WeConnect.user_db = []
+        models.WeConnect.business_db = []
+
+    def tearDown(self):
+        models.WeConnect.user_db = []
+        models.WeConnect.business_db = []
+
+    def test_register_business(self):
+        self.weconnect_test.post(
+            '/api/v1/auth/register',
+            content_type='application/json',
+            data=json.dumps(
+                dict(
+                    first_name='Harry',
+                    last_name='Potter',
+                    email='harry@aol.com',
+                    password='dumbledore')))
+        login = self.weconnect_test.post(
+            '/api/v1/auth/login',
+            content_type='application/json',
+            data=json.dumps(
+                dict(
+                    email='harry@aol.com',
+                    password='dumbledore')))
+        resp = json.loads(login.data.decode())
+        access_token = resp['access_token']
+        response = self.weconnect_test.post(
+            '/api/v1/businesses',
+            content_type='application/json',
+            data=json.dumps(
+                dict(
+                    name='Mortal Kombat',
+                    location='Earth',
+                    category='something',
+                    description='something',
+                    review=[])),
+            headers={
+                'Authorization': 'Bearer %s' % access_token})
+        self.assertIn(b'Mortal Kombat', response.data)
+        self.assertIn(b'Earth', response.data)
+        self.assertIn(b'something', response.data)
+        self.assertIn(b'user_id', response.data)
+        self.assertEqual(response.status_code, 201)
+
+    def test_update_business(self):
+        self.weconnect_test.post(
+            '/api/v1/auth/register',
+            content_type='application/json',
+            data=json.dumps(
+                dict(
+                    first_name='Harry',
+                    last_name='Potter',
+                    email='harry@aol.com',
+                    password='dumbledore')))
+        login = self.weconnect_test.post(
+            '/api/v1/auth/login',
+            content_type='application/json',
+            data=json.dumps(
+                dict(
+                    email='harry@aol.com',
+                    password='dumbledore')))
+        resp = json.loads(login.data.decode())
+        access_token = resp['access_token']
+        business = self.weconnect_test.post(
+            '/api/v1/businesses',
+            content_type='application/json',
+            data=json.dumps(
+                dict(
+                    name='Mortal Kombat',
+                    location='Earth',
+                    category='something',
+                    description='something',
+                    review=[])),
+            headers={
+                'Authorization': 'Bearer %s' % access_token})
+        biz_id = json.loads(business.get_data())['business']['business_id']
+        response = self.weconnect_test.put(
+            '/api/v1/businesses/' + str(biz_id),
+            content_type='application/json',
+            data=json.dumps(
+                dict(
+                    name='Mortal Kombat1',
+                    location='something_new',
+                    category='something_new',
+                    description='something_new')),
+            headers={
+                'Authorization': 'Bearer %s' % access_token})
+        self.assertIn(b'Mortal Kombat1', response.data)
+        self.assertIn(b'something_new', response.data)
+        self.assertIn(b'user_id', response.data)
+        self.assertTrue(response.status_code, 201)
+
+    def test_get_business(self):
+        self.weconnect_test.post(
+            '/api/v1/auth/register',
+            content_type='application/json',
+            data=json.dumps(
+                dict(
+                    first_name='Harry',
+                    last_name='Potter',
+                    email='harry@aol.com',
+                    password='dumbledore')))
+        login = self.weconnect_test.post(
+            '/api/v1/auth/login',
+            content_type='application/json',
+            data=json.dumps(
+                dict(
+                    email='harry@aol.com',
+                    password='dumbledore')))
+        resp = json.loads(login.data.decode())
+        access_token = resp['access_token']
+        business = self.weconnect_test.post(
+            '/api/v1/businesses',
+            content_type='application/json',
+            data=json.dumps(
+                dict(
+                    name='Mortal Kombat',
+                    location='Earth',
+                    category='something',
+                    description='something',
+                    review=[])),
+            headers={
+                'Authorization': 'Bearer %s' % access_token})
+        biz_id = json.loads(business.get_data())['business']['business_id']
+        response = self.weconnect_test.get(
+            '/api/v1/businesses/' + str(biz_id),
+            content_type='application/json',
+            headers={
+                'Authorization': 'Bearer %s' % access_token})
+        self.assertEqual(response.status_code, 200)
+
+    def test_get_businesses(self):
+        self.weconnect_test.post(
+            '/api/v1/auth/register',
+            content_type='application/json',
+            data=json.dumps(
+                dict(
+                    first_name='Harry',
+                    last_name='Potter',
+                    email='harry@aol.com',
+                    password='dumbledore')))
+        login = self.weconnect_test.post(
+            '/api/v1/auth/login',
+            content_type='application/json',
+            data=json.dumps(
+                dict(
+                    email='harry@aol.com',
+                    password='dumbledore')))
+        resp = json.loads(login.data.decode())
+        access_token = resp['access_token']
+        self.weconnect_test.post(
+            '/api/v1/businesses',
+            content_type='application/json',
+            data=json.dumps(
+                dict(
+                    name='Mortal Kombat',
+                    location='Earth',
+                    category='something',
+                    description='something',
+                    review=[])),
+            headers={
+                'Authorization': 'Bearer %s' % access_token})
+        response = self.weconnect_test.get(
+            '/api/v1/businesses',
+            content_type='application/json',
+            headers={
+                'Authorization': 'Bearer %s' % access_token})
+        self.assertEqual(response.status_code, 200)
+
+    def test_delete_business(self):
+        self.weconnect_test.post(
+            '/api/v1/auth/register',
+            content_type='application/json',
+            data=json.dumps(
+                dict(
+                    first_name='Harry',
+                    last_name='Potter',
+                    email='harry@aol.com',
+                    password='dumbledore')))
+        login = self.weconnect_test.post(
+            '/api/v1/auth/login',
+            content_type='application/json',
+            data=json.dumps(
+                dict(
+                    email='harry@aol.com',
+                    password='dumbledore')))
+        resp = json.loads(login.data.decode())
+        access_token = resp['access_token']
+        business = self.weconnect_test.post(
+            '/api/v1/businesses',
+            content_type='application/json',
+            data=json.dumps(
+                dict(
+                    name='Mortal Kombat',
+                    location='Earth',
+                    category='something',
+                    description='something',
+                    review=[])),
+            headers={
+                'Authorization': 'Bearer %s' % access_token})
+        biz_id = json.loads(business.get_data())['business']['business_id']
+        response = self.weconnect_test.delete(
+            '/api/v1/businesses/' + str(biz_id),
+            headers={
+                'Authorization': 'Bearer %s' % access_token})
+        self.assertTrue(response.status_code, 200)
+        result = self.weconnect_test.get(
+            '/api/v1/businesses',
+            content_type='application/json',
+            headers={
+                'Authorization': 'Bearer %s' % access_token})
+        self.assertEqual(
+            0, len(
+                json.loads(
+                    result.data.decode())['businesses']))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/tests_v1/test_reviews.py
+++ b/tests/tests_v1/test_reviews.py
@@ -1,0 +1,113 @@
+import flask
+import json
+import flask_jwt_extended
+import unittest
+
+from app import app
+from app.v1 import models, users
+
+
+class WeConnectViews(unittest.TestCase):
+    """Tests the enpoints contains in views.py"""
+
+    def setUp(self):
+        self.weconnect_test = app.test_client(self)
+        models.WeConnect.user_db = []
+        models.WeConnect.business_db = []
+
+    def tearDown(self):
+        models.WeConnect.user_db = []
+        models.WeConnect.business_db = []
+
+    def test_add_review(self):
+        self.weconnect_test.post(
+            '/api/v1/auth/register',
+            content_type='application/json',
+            data=json.dumps(
+                dict(
+                    first_name='Harry',
+                    last_name='Potter',
+                    email='harry@aol.com',
+                    password='dumbledore')))
+        login = self.weconnect_test.post(
+            '/api/v1/auth/login',
+            content_type='application/json',
+            data=json.dumps(
+                dict(
+                    email='harry@aol.com',
+                    password='dumbledore')))
+        resp = json.loads(login.data.decode())
+        access_token = resp['access_token']
+        business = self.weconnect_test.post(
+            '/api/v1/businesses',
+            content_type='application/json',
+            data=json.dumps(
+                dict(
+                    name='Mortal Kombat',
+                    location='Earth',
+                    category='something',
+                    description='something',
+                    review=[])),
+            headers={
+                'Authorization': 'Bearer %s' % access_token})
+        biz_id = json.loads(business.data.decode())['business']['business_id']
+        review = self.weconnect_test.post(
+            '/api/v1/businesses/' + str(biz_id) + '/reviews',
+            content_type='application/json',
+            data=json.dumps(
+                dict(
+                    review="Beautiful")),
+            headers={
+                'Authorization': 'Bearer %s' % access_token})
+        self.assertTrue(review.status_code, 200)
+
+    def test_get_reviews(self):
+        self.weconnect_test.post(
+            '/api/v1/auth/register',
+            content_type='application/json',
+            data=json.dumps(
+                dict(
+                    first_name='Harry',
+                    last_name='Potter',
+                    email='harry@aol.com',
+                    password='dumbledore')))
+        login = self.weconnect_test.post(
+            '/api/v1/auth/login',
+            content_type='application/json',
+            data=json.dumps(
+                dict(
+                    email='harry@aol.com',
+                    password='dumbledore')))
+        resp = json.loads(login.data.decode())
+        access_token = resp['access_token']
+        business = self.weconnect_test.post(
+            '/api/v1/businesses',
+            content_type='application/json',
+            data=json.dumps(
+                dict(
+                    name='Mortal Kombat',
+                    location='Earth',
+                    category='something',
+                    description='something',
+                    review=[])),
+            headers={
+                'Authorization': 'Bearer %s' % access_token})
+        biz_id = json.loads(business.data.decode())['business']['business_id']
+        self.weconnect_test.post(
+            '/api/v1/businesses/' + str(biz_id) + '/reviews',
+            content_type='application/json',
+            data=json.dumps(
+                dict(
+                    review="Beautiful")),
+            headers={
+                'Authorization': 'Bearer %s' % access_token})
+        get_review = self.weconnect_test.get(
+            '/api/v1/businesses/' + str(biz_id) + '/reviews',
+            content_type='application/json',
+            headers={
+                'Authorization': 'Bearer %s' % access_token})
+        self.assertTrue(get_review.status_code, 200)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
#### What's this PR do?
This pull request continues with the refactor started in pull request #36 and adds the business and review API endpoints in their own `businesses` package as well as separate tests within the `test_business` and `test_review` module inside the `tests_v1` package.

#### Where should the reviewer start?
The commit history of this pull request

#### How should this be manually tested?
After activating the `virtualenv`, run `python -m unittest /path/to/tests/tests_v1/test_users.py` for verbose output.