### PR TITLE
WIP: Validation: improve JSON schema for business and review endpoints

### DIFF
--- a/app/schemas/business_schema.py
+++ b/app/schemas/business_schema.py
@@ -18,22 +18,29 @@ business_schema = {
         "name": {
             "type": "string",
             "description": "The name of the business",
+            "minLength": 3,
             "maxLength": 255
         },
         "location": {
             "type": "string",
             "description": "The location of the business",
-            "maxLength": 255
+            "minLength": 3,
+            "maxLength": 255,
+            "pattern": "^[A-Za-z\\s]*$"
         },
         "category": {
             "type": "string",
             "description": "The category of the business",
-            "maxLength": 255
+            "minLength": 3,
+            "maxLength": 255,
+            "pattern": "^[A-Za-z\\s]*$"
         },
         "description": {
             "type": "string",
             "description": "The description of the business",
-            "maxLength": 255
+            "minLength": 3,
+            "maxLength": 255,
+            "pattern": "^[A-Za-z\\s]*$"
         },
         "review": {
             "type": "array"

--- a/app/schemas/review_schema.py
+++ b/app/schemas/review_schema.py
@@ -16,7 +16,8 @@ review_schema = {
             "maxLength": 255
         },
         "review": {
-            "type": "string"
+            "type": "string",
+            "pattern": "^[A-Za-z\\s]*$"
         }
     },
     "additionalProperties": False,

--- a/tests/tests_v1/test_business.py
+++ b/tests/tests_v1/test_business.py
@@ -91,13 +91,13 @@ class WeConnectViews(unittest.TestCase):
             data=json.dumps(
                 dict(
                     name='Mortal Kombat1',
-                    location='something_new',
-                    category='something_new',
-                    description='something_new')),
+                    location='something new',
+                    category='something new',
+                    description='something new')),
             headers={
                 'Authorization': 'Bearer %s' % access_token})
         self.assertIn(b'Mortal Kombat1', response.data)
-        self.assertIn(b'something_new', response.data)
+        self.assertIn(b'something new', response.data)
         self.assertIn(b'business_id', response.data)
         self.assertIn(b'user_id', response.data)
         self.assertTrue(response.status_code, 201)


### PR DESCRIPTION
#### What's this PR do?
This pull request improves the JSON schema for `business` and `review` API endpoints by adding the minimum and maximum lengths for fields to the `business_schema` and `review_schema` modules as well as pattern matching. Modified the test data to match the `schema`. 

#### Where should the reviewer start?
The commit history of this pull request

#### Background context
Pull request #44 

#### How should this be manually tested?
Running `python -m unittest tests/tests_v1/test_users.py` after activating the `virtualenv`.